### PR TITLE
Fix views namespacing errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
           aliasMappings: [
             {
               cwd: 'app/views',
-              src: ['**/*'],
+              src: ['**/*.hbs', '**/*.js'],
               dest: 'app/views',
               rename: function(cwd, src) {
                 // Little hack to ensure that file extension is preserved.


### PR DESCRIPTION
If we try to namespace our views (e.g. posts/new.hbs), grunt will throw an error 

``` bash
Cannot find module '..../app/views/posts' Use --force to continue.
```

This is happening in the browserify grunt task where the src pattern is set to '*_/_'. This commit specifies the src file patterns that we're interested in, namely: .hbs and .js.
