### PR TITLE
Fixed the single post route.

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -18,7 +18,7 @@ module.exports = function(match) {
     });
   });
 
-  match('/posts/:id', function(id, callback) {
+  match('/post/:id', function(id, callback) {
     console.log('post: ' + id);
 
     apiClient.get('/posts/' + id + '.json', function(err, res) {

--- a/app/views/Posts.jsx
+++ b/app/views/Posts.jsx
@@ -8,7 +8,7 @@ var Posts = React.createClass({
         <h1>Posts</h1>
         <ul>
         {this.props.posts.map(function(post, index) {
-          return <li key={index}><a href={'/posts/' + post.id}>{post.title}</a></li>;
+          return <li key={index}><a href={'/post/' + post.id}>{post.title}</a></li>;
         })}
         </ul>
         <Renderer renderer={this.props.renderer} />


### PR DESCRIPTION
Single posts would error when hit directly in the browser.
This fix changes the route from /posts/:id to /post/:id
in the routing table as well as the React component.

Fixes #15 