### PR TITLE
Disable recursive routes in server-side router

### DIFF
--- a/app/router/index.js
+++ b/app/router/index.js
@@ -9,7 +9,9 @@ module.exports = Router;
 function Router(routesFn) {
   if (routesFn == null) throw new Error("Must provide routes.");
 
-  this.directorRouter = new DirectorRouter(this.parseRoutes(routesFn));
+  this.directorRouter = new DirectorRouter(this.parseRoutes(routesFn)).configure({
+    recurse: false
+  });
   this.renderer = new Renderer;
 
   if (!isServer) {


### PR DESCRIPTION
Hi,

I was playing around with this tutorial, and I had trouble getting the posts section to work using the server side rendering.  It would crash each time I attempted to load `http://localhost:3030/posts/1`.  Client-side rendering worked fine.

I tracked the issue down to recursive route handling in Director.  It looks like both the `/posts` and `/posts:id` routes were being applied, causing a mismatch in callback parameters and subsequent crash.

It's hard to say, but this may have been a change on Director's part.  [According to their README](https://github.com/flatiron/director/blob/master/README.md#configuration), server-side routing has 'backwards' recursion turned on by default.  Looking at the code, however, [it is set to 'forward.'](https://github.com/flatiron/director/blob/master/lib/director/http/index.js#L30)  And it seems to have been changed [in an unrelated commit that didn't update the README](https://github.com/flatiron/director/commit/ed7d39e1e6f02041520610f509fc0b19441324cb).

This pull request just configures the DirectorRouter to disable recursive routes, after which the tutorial works on both client- and server-side loads.

Also, thank you for putting this tutorial together.  It has been a huge help in wrapping my head around this architecture.  Cheers,

-Will
