### PR TITLE
Added engines to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the client-side.
 
 ## Getting it running
 
-### Install Node.js >= 0.10.x
+### Install Node.js >= 0.10.x <=0.12.x
 
 If Node.js version >= 0.10.x is not already installed on your system, install it so you can run this app.
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "load-grunt-tasks": "^3.1.0",
     "reactify": "^0.15.2"
   },
+  "engineStrict": true,
+  "engines": {
+    "node": ">=0.10.x <=0.12.x"
+  },
   "browser": {
     "./app/router/renderer/index.js": "./app/router/renderer/client.js"
   }


### PR DESCRIPTION
node-pre-gyp is a dependency some where and it works only on those specific versions of node. I ran into the issue so, it's better to specify node engines in package.json.
